### PR TITLE
PyRIT update 0.6.0

### DIFF
--- a/pyritship/app.py
+++ b/pyritship/app.py
@@ -4,7 +4,7 @@ import asyncio
 import os
 import inspect
 import importlib
-from pyrit.common import default_values
+from pyrit.common import default_values, initialize_pyrit, IN_MEMORY
 from pyrit.prompt_converter import PromptConverter
 from pyrit.prompt_target import OpenAIChatTarget
 from pyrit.orchestrator import PromptSendingOrchestrator
@@ -56,7 +56,7 @@ def generate_prompt():
     global aoai_chat_target
     if (aoai_chat_target is None):
         aoai_chat_target = initialize_aoai_chat_target()
-    promptSendingOrchestrator = PromptSendingOrchestrator(prompt_target=aoai_chat_target)
+    promptSendingOrchestrator = PromptSendingOrchestrator(objective_target=aoai_chat_target)
     # Extract input data from json payload
     data = request.get_json()
     prompt_goal = data['prompt_goal']
@@ -106,4 +106,5 @@ def initialize_aoai_chat_target():
 if __name__ == '__main__':
     if os.environ.get("AZURE_OPENAI_GPT4O_CHAT_ENDPOINT") is None:
         load_dotenv()
+    initialize_pyrit(memory_db_type=IN_MEMORY)
     app.run(host='127.0.0.1', port=5001, debug=True)

--- a/pyritship/app.py
+++ b/pyritship/app.py
@@ -56,6 +56,7 @@ def generate_prompt():
     global aoai_chat_target
     if (aoai_chat_target is None):
         aoai_chat_target = initialize_aoai_chat_target()
+    
     promptSendingOrchestrator = PromptSendingOrchestrator(objective_target=aoai_chat_target)
     # Extract input data from json payload
     data = request.get_json()
@@ -96,6 +97,8 @@ def score():
     )
     
 def initialize_aoai_chat_target():
+    initialize_pyrit(memory_db_type=IN_MEMORY)
+
     aoai_chat_target = OpenAIChatTarget(
         deployment_name=os.environ.get("AZURE_OPENAI_GPT4O_CHAT_DEPLOYMENT"),
         endpoint=os.environ.get("AZURE_OPENAI_GPT4O_CHAT_ENDPOINT"),
@@ -106,5 +109,4 @@ def initialize_aoai_chat_target():
 if __name__ == '__main__':
     if os.environ.get("AZURE_OPENAI_GPT4O_CHAT_ENDPOINT") is None:
         load_dotenv()
-    initialize_pyrit(memory_db_type=IN_MEMORY)
-    app.run(host='127.0.0.1', port=5001, debug=True)
+    app.run(host='127.0.0.1', port=5001, debug=True, threaded=False)


### PR DESCRIPTION
Fixes #3

Two breaking changes in the 0.6.0 PyRIT release:
1. initialize_pyrit(memory_db_type=IN_MEMORY) needs to be called. However, there is an issue where the DB is initialized globally with this function but the DB is destroyed when the orchestrator is destroyed which happens for every call in PyRIT Ship. PyRIT team is looking for a solution - for now we turned off threading for Flax to avoid the issue.
2. PrompSendingOrchestrator renamed parameter "prompt_target" to "object_target"

Both issues are resolved with this PR.